### PR TITLE
Fix ObjectSpaceTangent implicit truncation warning

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [11.0.1] - 2020-10-21
+
+### Added
+
+### Changed
+
+### Fixed
+- Fixed an issue where generated `BuildVertexDescriptionInputs()` produced an HLSL warning, "implicit truncation of vector type"
+
 ## [11.0.0] - 2020-10-21
 
 ### Added

--- a/com.unity.shadergraph/Editor/Generation/Templates/BuildVertexDescriptionInputs.template.hlsl
+++ b/com.unity.shadergraph/Editor/Generation/Templates/BuildVertexDescriptionInputs.template.hlsl
@@ -7,7 +7,7 @@ VertexDescriptionInputs BuildVertexDescriptionInputs(Attributes input)
     $VertexDescriptionInputs.WorldSpaceNormal:          output.WorldSpaceNormal =            TransformObjectToWorldNormal(input.normalOS);
     $VertexDescriptionInputs.ViewSpaceNormal:           output.ViewSpaceNormal =             TransformWorldToViewDir(output.WorldSpaceNormal);
     $VertexDescriptionInputs.TangentSpaceNormal:        output.TangentSpaceNormal =          float3(0.0f, 0.0f, 1.0f);
-    $VertexDescriptionInputs.ObjectSpaceTangent:        output.ObjectSpaceTangent =          input.tangentOS;
+    $VertexDescriptionInputs.ObjectSpaceTangent:        output.ObjectSpaceTangent =          input.tangentOS.xyz;
     $VertexDescriptionInputs.WorldSpaceTangent:         output.WorldSpaceTangent =           TransformObjectToWorldDir(input.tangentOS.xyz);
     $VertexDescriptionInputs.ViewSpaceTangent:          output.ViewSpaceTangent =            TransformWorldToViewDir(output.WorldSpaceTangent);
     $VertexDescriptionInputs.TangentSpaceTangent:       output.TangentSpaceTangent =         float3(1.0f, 0.0f, 0.0f);


### PR DESCRIPTION
### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR. If you do add documentation, make sure to add the relevant Graphics Docs team member as a reviewer of the PR. If you are not sure which person to add, see the [Docs team contacts sheet](https://docs.google.com/spreadsheets/d/1rgUWWgwLFEHIQ3Rz-LnK6PAKmbM49DZZ9al4hvnztOo/edit#gid=1058860420).
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
When creating a new URP Lit shader graph, changing the input color in any way results in an HLSL warning, `implicit truncation of vector type`, in the generated `BuildVertexDescriptionInputs()` function, because `output.ObjectSpaceTangent` is of type `float3` and `input.tangentOS` is of type `float4`.  To avoid the warning, an `.xyz` swizzle is used to explicitly convert to `float3`.

Please note that while this warning may not affect behavior of the shader on PC, it can become an error when generating GLSL shaders for other platforms.  Ideally, warnings in shader graph shaders should only be produced by parts of the graph that were created by users.

---
### Testing status
I created a new URP Lit shader graph, and adjusted the input color value.  I observed that the generated shader reported a warning, `implicit truncation of vector type`, in `BuildVertexDescriptionInputs()`.  I fixed the template, `BuildVertexDescriptionInputs.template.hlsl`, then reimported the shader graph, and the warning no longer appeared.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
